### PR TITLE
NotifyBar for OSGi usage of BadgeList

### DIFF
--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/BadgeListItemAdapter.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/BadgeListItemAdapter.java
@@ -1,0 +1,70 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.markup.html.badge.notifybar;
+
+import org.apache.wicket.markup.html.link.AbstractLink;
+import org.apache.wicket.model.AbstractReadOnlyModel;
+import org.apache.wicket.model.IModel;
+import org.cdlflex.ui.markup.html.badge.BadgeListItem;
+
+/**
+ * Wraps an INotifyBarComponent to be used as a BadgeListItem.
+ */
+public class BadgeListItemAdapter extends BadgeListItem {
+
+    private static final long serialVersionUID = 1L;
+
+    private INotifyBarComponent component;
+
+    public BadgeListItemAdapter(final INotifyBarComponent component) {
+        super();
+        this.component = component;
+        setBadgeModel(new BadgeModel());
+        setLabelModel(new LabelModel());
+    }
+
+    @Override
+    public AbstractLink createLink(String id) {
+        if (component instanceof INavigatableNotifyBarComponent) {
+            return ((INavigatableNotifyBarComponent) component).createLink(id);
+        } else {
+            return super.createLink(id);
+        }
+    }
+
+    /**
+     * Readonly Model that reads the badge display model from the INotifyBarComponent.
+     */
+    private class BadgeModel extends AbstractReadOnlyModel<Object> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object getObject() {
+            Object value = component.getValue();
+            return (value instanceof IModel) ? ((IModel) value).getObject() : value;
+        }
+    }
+
+    /**
+     * Readonly model that reads the label display model from the INotifyBarComponent.
+     */
+    private class LabelModel extends AbstractReadOnlyModel<String> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getObject() {
+            return component.getLabel();
+        }
+    }
+}

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INavigatableNotifyBarComponent.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INavigatableNotifyBarComponent.java
@@ -1,0 +1,29 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.markup.html.badge.notifybar;
+
+import org.apache.wicket.markup.html.link.AbstractLink;
+
+/**
+ * A INotifyBarComponent that can be clicked which the navigates to some location.
+ */
+public interface INavigatableNotifyBarComponent extends INotifyBarComponent {
+    /**
+     * Creates a link for the notify bar component.
+     * 
+     * @param id the component id that should be used for the link.
+     * @return a new link
+     */
+    AbstractLink createLink(String id);
+}

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INotifyBarComponent.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INotifyBarComponent.java
@@ -1,0 +1,52 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.markup.html.badge.notifybar;
+
+import java.io.Serializable;
+
+/**
+ * INotifyBarComponent.
+ */
+public interface INotifyBarComponent extends Serializable {
+
+    int DEFAULT_PRIORITY = 0;
+
+    /**
+     * The sorting priority within the bar itself. Higher means the component will be rendered further left.
+     * 
+     * @return A priority
+     */
+    int getPriority();
+
+    /**
+     * Whether or not this component is visible in the bar.
+     *
+     * @return true if it is visible
+     */
+    boolean isVisible();
+
+    /**
+     * Returns the localized label to display, or null if none should be shown (not recommended).
+     * 
+     * @return A localized string label
+     */
+    String getLabel();
+
+    /**
+     * Can return a serializable value that can be rendered as string, or a Wicket IModel.
+     * 
+     * @return a concrete value or a Wicket Model
+     */
+    Object getValue();
+}

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INotifyBarComponentProvider.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/INotifyBarComponentProvider.java
@@ -1,0 +1,29 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.markup.html.badge.notifybar;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * Provides a collection of INotifyBarComponent.
+ */
+public interface INotifyBarComponentProvider extends Serializable {
+    /**
+     * Returns a list of INotifyBarComponents components.
+     * 
+     * @return a list of INotifyBarComponents
+     */
+    Collection<INotifyBarComponent> getComponents();
+}

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/NotifyBar.html
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/NotifyBar.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel>
+  <div class="container">
+    <div class="notifybar-collapse">
+      <ul wicket:id="badge-list" class="notify-tabs"></ul>
+    </div>
+  </div>
+</wicket:panel>
+</body>
+</html>

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/NotifyBar.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/markup/html/badge/notifybar/NotifyBar.java
@@ -1,0 +1,132 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.markup.html.badge.notifybar;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.AbstractReadOnlyModel;
+import org.cdlflex.ui.behavior.CssClassNameAppender;
+import org.cdlflex.ui.markup.html.badge.BadgeList;
+import org.cdlflex.ui.markup.html.badge.BadgeListItem;
+import org.cdlflex.ui.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Component that dynamically populates a {@link org.cdlflex.ui.markup.html.badge.BadgeList} with components provided
+ * by a {@link org.cdlflex.ui.markup.html.badge.notifybar.INotifyBarComponentProvider}.
+ * <p/>
+ * Its purpose is to bridge the gap between the {@link BadgeList} and OSGi service-based design. In an OSGi use-case,
+ * one would implement an INotifyBarComponentProvider as a service aggregator, which allows INotifyBarComponents to be
+ * provided from different bundles.
+ */
+public class NotifyBar extends Panel {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotifyBar.class);
+
+    private INotifyBarComponentProvider componentProvider;
+
+    public NotifyBar(String id, INotifyBarComponentProvider componentProvider) {
+        super(id);
+        this.componentProvider = componentProvider;
+    }
+
+    public INotifyBarComponentProvider getComponentProvider() {
+        return componentProvider;
+    }
+
+    public void setComponentProvider(INotifyBarComponentProvider componentProvider) {
+        this.componentProvider = componentProvider;
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+
+        add(newBadgeList("badge-list"));
+    }
+
+    /**
+     * Factory method that creates the BadgeList to be displayed.
+     * 
+     * @param id the component id
+     * @return a new BadgeList
+     */
+    protected Component newBadgeList(String id) {
+        return new BadgeList(id, new BadgeItemProvidingModel());
+    }
+
+    @Override
+    protected void onComponentTag(ComponentTag tag) {
+        super.onComponentTag(tag);
+        CssClassNameAppender.append(tag, "notifybar");
+    }
+
+    /**
+     * Model that provides BadgeListItems from the INotifyBarComponentProvider of this NotifyBar instance.
+     */
+    protected class BadgeItemProvidingModel extends AbstractReadOnlyModel<List<? extends BadgeListItem>> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public List<? extends BadgeListItem> getObject() {
+            INotifyBarComponentProvider provider = getComponentProvider();
+            if (provider == null) {
+                LOG.warn("INotifyBarComponentProvider is null, can not populate NotifyBar");
+                return Collections.emptyList();
+            }
+
+            List<INotifyBarComponent> components = new ArrayList<>(provider.getComponents());
+            Collections.retain(components, new VisibilityFilter()); // remove all components that are not visible
+            Collections.sort(components, new ComponentPriorityComparator()); // sort them by priority
+            return Collections.map(components, new BadgeListItemFactory()); // create the BadgeListItems
+        }
+    }
+
+    /**
+     * A Comparator that compares INotifyBarComponent elements based on their priority.
+     */
+    private static class ComponentPriorityComparator implements Comparator<INotifyBarComponent> {
+        @Override
+        public int compare(INotifyBarComponent o1, INotifyBarComponent o2) {
+            return Integer.compare(o1.getPriority(), o2.getPriority());
+        }
+    }
+
+    /**
+     * Callback that creates BadgeListItemAdapter instances from INotifyBarComponent.
+     */
+    private static class BadgeListItemFactory implements Collections.Callback<INotifyBarComponent, BadgeListItem> {
+        @Override
+        public BadgeListItem call(INotifyBarComponent component) {
+            return new BadgeListItemAdapter(component);
+        }
+    }
+
+    /**
+     * Predicate that delegates access to {@link INotifyBarComponent#isVisible()}.
+     */
+    private static class VisibilityFilter implements Collections.Predicate<INotifyBarComponent> {
+        @Override
+        public Boolean call(INotifyBarComponent object) {
+            return object.isVisible();
+        }
+    }
+}

--- a/flex-ui-core/src/main/java/org/cdlflex/ui/util/Collections.java
+++ b/flex-ui-core/src/main/java/org/cdlflex/ui/util/Collections.java
@@ -15,6 +15,7 @@ package org.cdlflex.ui.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -259,6 +260,29 @@ public final class Collections {
         }
 
         return list;
+    }
+
+    /**
+     * Sorts a list.
+     * 
+     * @param list list to sort
+     * @param <T> Collection element type
+     * @see java.util.Collections#sort(java.util.List)
+     */
+    public static <T extends Comparable<? super T>> void sort(List<T> list) {
+        java.util.Collections.sort(list);
+    }
+
+    /**
+     * Sorts a list.
+     * 
+     * @param list list to sort
+     * @param comparator comparator to use
+     * @param <T> Collection element type
+     * @see java.util.Collections#sort(java.util.List, java.util.Comparator)
+     */
+    public static <T> void sort(List<T> list, Comparator<T> comparator) {
+        java.util.Collections.sort(list, comparator);
     }
 
     /**

--- a/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/ExamplePage.java
+++ b/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/ExamplePage.java
@@ -27,6 +27,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.io.IClusterable;
 import org.cdlflex.ui.behavior.CssClassNameAppender;
+import org.cdlflex.ui.markup.html.badge.notifybar.NotifyBar;
 import org.cdlflex.ui.pages.examples.AlertsPage;
 import org.cdlflex.ui.pages.examples.BadgesPage;
 import org.cdlflex.ui.pages.examples.ButtonsPage;
@@ -37,6 +38,7 @@ import org.cdlflex.ui.pages.examples.FlexTablePage;
 import org.cdlflex.ui.pages.examples.FormComponentsPage;
 import org.cdlflex.ui.pages.examples.IconsPage;
 import org.cdlflex.ui.pages.examples.NavbarPage;
+import org.cdlflex.ui.pages.examples.NotifyBarPage;
 import org.cdlflex.ui.pages.examples.TablePage;
 
 /**
@@ -57,6 +59,7 @@ public class ExamplePage extends BasePage {
             add(new LinkItem(IconsPage.class, Model.of("Bootstrap GlyphIcons")));
             add(new LinkItem(ButtonsPage.class, Model.of("Buttons")));
             add(new LinkItem(BadgesPage.class, Model.of("Badges")));
+            add(new LinkItem(NotifyBarPage.class, Model.of("NotifyBar")));
             add(new LinkItem(NavbarPage.class, Model.of("Navbars")));
             add(new LinkItem(DialogsPage.class, Model.of("Dialogs")));
             add(new LinkItem(TablePage.class, Model.of("Tables")));

--- a/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/examples/NotifyBarPage.html
+++ b/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/examples/NotifyBarPage.html
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<head>
+  <wicket:head>
+    <style type="text/css">
+
+      .notifybar {
+        z-index: 10;
+
+        height: 28px;
+        width: 100%;
+
+        background-color: #3E3535;
+      }
+
+      .notifybar > .container {
+        margin: 0 10px;
+        height: 28px;
+      }
+
+      .notifybar-collapse {
+        height: 25px;
+        overflow-x: visible;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .notifybar-collapse:before,
+      .notifybar-collapse:after {
+        content: " ";
+        /* 1 */
+        display: table;
+        /* 2 */
+      }
+
+      .notifybar-collapse:after {
+        clear: both;
+      }
+
+      .notify-tabs {
+        float: left;
+        margin: 0;
+        padding-left: 0;
+        list-style: none;
+      }
+
+      .notify-tabs:after {
+        clear: both;
+      }
+
+      .notify-tabs > li {
+        float: left;
+        padding: 3px 10px;
+
+        color: white;
+        font-size: 13px;
+        letter-spacing: 1px;
+        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+      }
+      .notify-tabs > li > a {
+        color: white;
+      }
+      .notify-tabs > li  .badge {
+        text-indent: 0px;
+        margin-left: 10px;
+        padding: 3px 7px 1px 7px;
+        background: rgba(128, 128, 128, 0.2);
+        -webkit-box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.5), 0 1px 0 rgba(255, 255, 255, 0.5);
+        -moz-box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.5), 0 1px 0 rgba(255, 255, 255, 0.5);
+        box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.5), 0 1px 0 rgba(255, 255, 255, 0.5);
+      }
+    </style>
+  </wicket:head>
+</head>
+<body>
+<wicket:extend>
+  <h1 class="page-header">Notify Bar</h1>
+
+  <h2>Basic NotifyBar</h2>
+
+  <p>
+    The <code>NotifyBar</code> component utilises <code>INotifyBarComponent</code> extensions to render components
+    within a list of bootstrap <code>badge</code> items.
+  </p>
+
+  <div wicket:id="notify-bar">[]</div>
+
+</wicket:extend>
+</body>
+</html>

--- a/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/examples/NotifyBarPage.java
+++ b/flex-ui-examples/src/main/java/org/cdlflex/ui/pages/examples/NotifyBarPage.java
@@ -1,0 +1,148 @@
+/**
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.cdlflex.ui.pages.examples;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.wicket.markup.html.link.AbstractLink;
+import org.apache.wicket.model.Model;
+import org.cdlflex.ui.markup.html.badge.notifybar.INavigatableNotifyBarComponent;
+import org.cdlflex.ui.markup.html.badge.notifybar.INotifyBarComponent;
+import org.cdlflex.ui.markup.html.badge.notifybar.INotifyBarComponentProvider;
+import org.cdlflex.ui.markup.html.badge.notifybar.NotifyBar;
+import org.rauschig.wicketjs.IJavaScript;
+import org.rauschig.wicketjs.JsCall;
+import org.rauschig.wicketjs.markup.html.JsLink;
+
+/**
+ * NotifyBarPage
+ */
+public class NotifyBarPage extends StripTagExamplePage {
+    private static final long serialVersionUID = 1L;
+
+    public NotifyBarPage() {
+        add(new NotifyBar("notify-bar", new NotifyBarComponentProvider()));
+    }
+
+    private class NotifyBarComponentProvider implements INotifyBarComponentProvider {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public List<INotifyBarComponent> getComponents() {
+            return Arrays.asList(new INotifyBarComponent() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public int getPriority() {
+                    return DEFAULT_PRIORITY;
+                }
+
+                @Override
+                public boolean isVisible() {
+                    return true;
+                }
+
+                @Override
+                public String getLabel() {
+                    return "Just 10";
+                }
+
+                @Override
+                public Object getValue() {
+                    return 10;
+                }
+            }, new INotifyBarComponent() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public int getPriority() {
+                    return 10;
+                }
+
+                @Override
+                public boolean isVisible() {
+                    return true;
+                }
+
+                @Override
+                public String getLabel() {
+                    return "Shows a model";
+                }
+
+                @Override
+                public Object getValue() {
+                    return Model.of(42);
+                }
+            }, new INotifyBarComponent() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public int getPriority() {
+                    return 100;
+                }
+
+                @Override
+                public boolean isVisible() {
+                    return false;
+                }
+
+                @Override
+                public String getLabel() {
+                    return "Invisible";
+                }
+
+                @Override
+                public Object getValue() {
+                    return Model.of(42);
+                }
+            }, new INavigatableNotifyBarComponent() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public int getPriority() {
+                    return 5;
+                }
+
+                @Override
+                public boolean isVisible() {
+                    return true;
+                }
+
+                @Override
+                public AbstractLink createLink(String id) {
+                    return new JsLink(id) {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public IJavaScript onClick() {
+                            return new JsCall("alert", "I was clicked!");
+                        }
+                    };
+                }
+
+                @Override
+                public String getLabel() {
+                    return "With a link";
+                }
+
+                @Override
+                public Object getValue() {
+                    return "String value";
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
An implementation of a `INotifyBarComponentProvider` would contain two lists (for `INotifyBarComponent` and `INavigatableNotifyBarComponent`), which are reference-lists that aggregate exported services of those component interfaces.
The instance of `INotifyBarComponentProvider` is then injected into the BasePage which creates the `NotifyBar` instance.